### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/utils/locator.js
+++ b/lib/utils/locator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Q = require('q');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var evaluator = require('./evaluator');
 var tinto = {};
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "inquirer": "^1.0.0",
     "jquery": "^2.1.1",
     "lodash": "^4.0.0",
-    "node-uuid": "^1.4.3",
     "q": "^1.2.0",
-    "selenium-webdriver": "^2.48.2"
+    "selenium-webdriver": "^2.48.2",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai-as-promised": "^5.1.0",

--- a/test/utils/locator.spec.js
+++ b/test/utils/locator.spec.js
@@ -52,7 +52,7 @@ describe('Locator', function() {
       getElement: sinon.stub().returns(Q.resolve(parent))
     };
 
-    mockery.registerMock('node-uuid', uuid);
+    mockery.registerMock('uuid', uuid);
     mockery.registerMock('./evaluator', evaluator);
 
     Locator = require('../../lib/utils/locator');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.