### PR TITLE
expose webdriver through tinto.browser.getDriver()

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -42,6 +42,13 @@ tinto.Browser.prototype.getPage = function() {
 };
 
 /**
+ * @returns {webdriver.WebDriver}
+ */
+tinto.Browser.prototype.getDriver = function() {
+  return evaluator.getDriver();
+};
+
+/**
  * @param {string} [url]
  */
 tinto.Browser.prototype.open = function(url) {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -96,6 +96,12 @@ describe('Browser', function() {
     expect(browser.navigate).to.equal('test');
   });
 
+  it('should expose the evaluator driver', function() {
+    evaluator.getDriver.returns('test');
+
+    expect(browser.getDriver()).to.equal('test');
+  });
+
   it('should close the evaluator', function() {
     browser.open();
     evaluator.close.returns(Q.resolve());


### PR DESCRIPTION
closes #50 